### PR TITLE
Change how version string is loaded from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint --ext .ts src/",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
-    "test:coverage": "npm run test -- --coverage",
-    "test:watch": "npm run test -- --watch"
+    "test:coverage": "npm run test -- --coverage --resolveJsonModule",
+    "test:watch": "npm run test -- --watch --resolveJsonModule"
   },
   "dependencies": {
     "axios": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "dist"
   ],
   "scripts": {
-    "build_for_example": "rimraf example/node_modules/@duosecurity/duo_universal && tsc --project tsconfig.build.json --outDir example/node_modules/@duosecurity/duo_universal --resolveJsonModule",
-    "build": "rimraf dist && tsc --project tsconfig.build.json --resolveJsonModule",
+    "build_for_example": "rimraf example/node_modules/@duosecurity/duo_universal && tsc --project tsconfig.build.json --outDir example/node_modules/@duosecurity/duo_universal",
+    "build": "rimraf dist && tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "lint": "eslint --ext .ts src/",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
-    "test:coverage": "npm run test -- --coverage --resolveJsonModule",
-    "test:watch": "npm run test -- --watch --resolveJsonModule"
+    "test:coverage": "npm run test -- --coverage",
+    "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
     "axios": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "dist"
   ],
   "scripts": {
-    "build_for_example": "rimraf example/node_modules/@duosecurity/duo_universal && tsc --project tsconfig.build.json --outDir example/node_modules/@duosecurity/duo_universal",
-    "build": "rimraf dist && tsc --project tsconfig.build.json",
+    "build_for_example": "rimraf example/node_modules/@duosecurity/duo_universal && tsc --project tsconfig.build.json --outDir example/node_modules/@duosecurity/duo_universal --resolveJsonModule",
+    "build": "rimraf dist && tsc --project tsconfig.build.json --resolveJsonModule",
     "prepublishOnly": "npm run build",
     "lint": "eslint --ext .ts src/",
     "lint:fix": "npm run lint -- --fix",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import fs from 'fs';
-
-const pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf-8' }));
+import { version } from '../package.json';
 
 export const CLIENT_ID_LENGTH = 20;
 export const CLIENT_SECRET_LENGTH = 40;
@@ -16,7 +14,7 @@ export const JTI_LENGTH = 36;
 export const JWT_EXPIRATION = 300;
 export const JWT_LEEWAY = 60;
 
-export const USER_AGENT = `duo_universal_node/${pkg.version}`;
+export const USER_AGENT = `duo_universal_node/${version}`;
 export const SIG_ALGORITHM = 'HS512';
 export const GRANT_TYPE = 'authorization_code';
 export const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "rootDir": "src",
+    "rootDirs": ["src", "."],
     "types": [
       "node",
       "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,19 +11,10 @@
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "rootDirs": ["src", "."],
-    "types": [
-      "node",
-      "jest",
-      "jest-extended"
-    ]
+    "types": ["node", "jest", "jest-extended"]
   },
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Load package.json using `require` rather than a file read operation

## Description
Issue #5 identified that the way this library loads its version data from `package.json` will
lead to either the wrong version string being put into the user-agent string or a node error
depending on which `package.json` file is read.

This PR remidies this issue by using `require` rather than a raw file read, meaning that paths
will be interpreted relative to the source file rather than from the node project root.

## Motivation and Context
Issue #5, not breaking people using webpack and generally wanting to have accurate vesrion data in the user-agent string.

## How Has This Been Tested?
I've tested this in a web-packed app but I also never got the error indicated in issue #5 so I'm
curious if this fixes the problems identified there.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
