### PR TITLE
Package JSON fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
   },
   "files": [
+    "package.json",
     "dist"
   ],
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,12 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { version } from '../package.json';
+import fs from 'fs';
+import path from 'path';
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../package.json'), { encoding: 'utf-8' })
+);
 
 export const CLIENT_ID_LENGTH = 20;
 export const CLIENT_SECRET_LENGTH = 40;
@@ -14,7 +19,7 @@ export const JTI_LENGTH = 36;
 export const JWT_EXPIRATION = 300;
 export const JWT_LEEWAY = 60;
 
-export const USER_AGENT = `duo_universal_node/${version}`;
+export const USER_AGENT = `duo_universal_node/${pkg.version}`;
 export const SIG_ALGORITHM = 'HS512';
 export const GRANT_TYPE = 'authorization_code';
 export const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import fs from 'fs';
-
-const pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf-8' }));
+import { version } from '../package.json';
 
 export const CLIENT_ID_LENGTH = 20;
 export const CLIENT_SECRET_LENGTH = 40;
@@ -16,7 +14,7 @@ export const JTI_LENGTH = 36;
 export const JWT_EXPIRATION = 300;
 export const JWT_LEEWAY = 60;
 
-export const USER_AGENT = `duo_universal_node/${pkg.version}`;
+export const USER_AGENT = `duo_universal_node/${version}`;
 export const SIG_ALGORITHM = 'HS512';
 export const GRANT_TYPE = 'authorization_code';
 export const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';


### PR DESCRIPTION
- Change how version string is loaded from package.json


## Description
The previous solution of loading the `package.json` file via `import` statement doesn't seem to
work in all cases. The new solution is to prepend the directory path to `package.json` prior to
reading the file.

## Motivation and Context
Some have had issues with `package.json` not being found during installation of this package.

## How Has This Been Tested?
I tested this locally and verified that the version number is reported correctly.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
