### PR TITLE
Correcting Base64 String for random state

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@
 import { randomBytes } from 'crypto';
 
 function bytesToBase64url(s: Buffer): string {
-  return s.toString('base64').replace('+', '-').replace('/', '_');
+  return s.toString('base64url');
 }
 
 export const generateRandomString = (length: number): string => {


### PR DESCRIPTION
## Description

The replace function requires a regular expression if you want it to replace more than one instance of the sanitized characters. My change switches the string format from base64 to base64url which renders the entire string url safe and eliminates the need for string replacement.



## Motivation and Context
This fix is required because the current version causes some users to fail logins because the state does not match the original state when it is returned.

This fix is in reference to this issue: https://github.com/duosecurity/duo_universal_nodejs/issues/28

## How Has This Been Tested?
I ran your unit tests and also created my own test where I submitted the state an compared it 100000 times to make sure it was always equal to the original state after coming in through the HTTP engine of NodeJS.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
