### PR TITLE
Override glob-parent to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@duosecurity/duo_universal",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@duosecurity/duo_universal",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.2.2",
@@ -2616,18 +2616,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "ts-jest": "^29.0.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
+  },
+  "overrides": {
+    "glob-parent": "^6.0.2"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
glob-parent 5.1.2 is a dev dependency with a CVE https://nvd.nist.gov/vuln/detail/cve-2021-35065

This sets an override so glob-parent will always be 6.0.2+, even if the nested dependency asks for 5.1.2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To keep dependencies up-to-date and free of CVEs

## How Has This Been Tested?
Installing in clean directory, I confirmed only the glob-parent 6.0.2 version was installed in node_modules. I also confirmed the unit tests and example app still work.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
