### PR TITLE
Add constructor parameter to disable CA pinning

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,7 @@ export type ClientOptions = {
   apiHost: string;
   redirectUrl: string;
   useDuoCodeAttribute?: boolean;
+  enableCAPinning?: boolean;
 };
 
 export class Client {
@@ -46,12 +47,15 @@ export class Client {
 
   private useDuoCodeAttribute: boolean;
 
+  readonly enableCAPinning: boolean;
+
   private axios: AxiosInstance;
 
   constructor(options: ClientOptions) {
     this.validateInitialConfig(options);
 
-    const { clientId, clientSecret, apiHost, redirectUrl, useDuoCodeAttribute } = options;
+    const { clientId, clientSecret, apiHost, redirectUrl, useDuoCodeAttribute, enableCAPinning } =
+      options;
 
     this.clientId = clientId;
     this.clientSecret = new TextEncoder().encode(clientSecret);
@@ -59,9 +63,10 @@ export class Client {
     this.baseURL = `https://${this.apiHost}`;
     this.redirectUrl = redirectUrl;
     this.useDuoCodeAttribute = useDuoCodeAttribute ?? true;
-
+    this.enableCAPinning = enableCAPinning ?? true;
     const agent = new https.Agent({
-      ca: constants.DUO_PINNED_CERT,
+      ...(this.enableCAPinning ? { ca: constants.DUO_PINNED_CERT } : {}),
+      rejectUnauthorized: true,
     });
 
     this.axios = axios.create({

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 import axios from 'axios';
-import { beforeAll, describe, it, expect, vi } from 'vitest';
+import https from 'https';
+import { beforeAll, describe, it, expect, vi, type MockInstance } from 'vitest';
 import { Client, DuoException, constants, util } from '../../src';
 
 const clientOps = {
@@ -82,5 +83,47 @@ describe('Client instance', () => {
 
     expect(typeof state).toBe('string');
     expect(state.length).toBe(constants.DEFAULT_STATE_LENGTH);
+  });
+});
+
+describe('CA Pinning', () => {
+  let agentSpy: MockInstance;
+
+  beforeAll(() => {
+    vi.spyOn(axios, 'create').mockReturnThis();
+    agentSpy = vi.spyOn(https, 'Agent') as unknown as MockInstance;
+  });
+
+  it('CA pinning is enabled by default', () => {
+    const client = new Client(clientOps);
+
+    expect(client.enableCAPinning).toBe(true);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ca: constants.DUO_PINNED_CERT,
+        rejectUnauthorized: true,
+      }),
+    );
+  });
+
+  it('CA pinning can be disabled via constructor parameter', () => {
+    const client = new Client({ ...clientOps, enableCAPinning: false });
+
+    expect(client.enableCAPinning).toBe(false);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        ca: constants.DUO_PINNED_CERT,
+      }),
+    );
+  });
+
+  it('TLS verification is still enforced when CA pinning is disabled', () => {
+    new Client({ ...clientOps, enableCAPinning: false });
+
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rejectUnauthorized: true,
+      }),
+    );
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `enableCAPinning` option to `ClientOptions` constructor parameter (default: `true`).
When disabled, the HTTPS agent validates via OS trust store instead of pinned CAs. 
`rejectUnauthorized: true` is always explicitly set to ensure TLS verification cannot be bypassed regardless of the pinning setting.
             
## Motivation and Context
Provides a configuration option to disable CA pinning for customers who cannot upgrade during a CA bundle transition.

## How Has This Been Tested?
Added unit tests covering:
- CA pinning is enabled by default
- CA pinning can be disabled via constructor parameter
- TLS verification is still enforced when CA pinning is disabled

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
