### PR TITLE
Add CA bundle version and CA pinning status to the user-agent string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -69,10 +69,13 @@ export class Client {
       rejectUnauthorized: true,
     });
 
+    const userAgent = `${constants.USER_AGENT} node/${process.versions.node} v8/${process.versions.v8} ca_bundle/${constants.CA_BUNDLE_VERSION} (ca_pinning=${this.enableCAPinning ? 'enabled' : 'disabled'})`;
+
     this.axios = axios.create({
       baseURL: this.baseURL,
       httpsAgent: agent,
       httpAgent: Error('HTTP disabled. Must use HTTPS'),
+      headers: { 'User-Agent': userAgent },
     });
   }
 
@@ -311,11 +314,6 @@ export class Client {
       const { data } = await this.axios.post<TokenResponse>(
         this.TOKEN_ENDPOINT,
         new globalThis.URLSearchParams(request),
-        {
-          headers: {
-            'user-agent': `${constants.USER_AGENT} node/${process.versions.node} v8/${process.versions.v8}`,
-          },
-        },
       );
 
       /* Verify that we are receiving the expected response from Duo */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const JTI_LENGTH = 36;
 export const JWT_EXPIRATION = 300;
 export const JWT_LEEWAY = 60;
 
+export const CA_BUNDLE_VERSION = '1.0';
 export const USER_AGENT = `duo_universal_node/${version}`;
 export const SIG_ALGORITHM = 'HS512';
 export const GRANT_TYPE = 'authorization_code';

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -86,6 +86,34 @@ describe('Client instance', () => {
   });
 });
 
+describe('User Agent', () => {
+  let axiosCreateSpy: MockInstance;
+
+  beforeAll(() => {
+    axiosCreateSpy = vi.spyOn(axios, 'create').mockReturnThis();
+  });
+
+  it('User agent includes ca_bundle version and ca_pinning=enabled when pinning is on', () => {
+    new Client(clientOps);
+
+    const config = axiosCreateSpy.mock.lastCall?.[0];
+    const ua = config?.headers?.['User-Agent'] as string;
+
+    expect(ua).toContain(`ca_bundle/${constants.CA_BUNDLE_VERSION}`);
+    expect(ua).toContain('(ca_pinning=enabled)');
+  });
+
+  it('User agent includes ca_pinning=disabled when pinning is off', () => {
+    new Client({ ...clientOps, enableCAPinning: false });
+
+    const config = axiosCreateSpy.mock.lastCall?.[0];
+    const ua = config?.headers?.['User-Agent'] as string;
+
+    expect(ua).toContain(`ca_bundle/${constants.CA_BUNDLE_VERSION}`);
+    expect(ua).toContain('(ca_pinning=disabled)');
+  });
+});
+
 describe('CA Pinning', () => {
   let agentSpy: MockInstance;
 


### PR DESCRIPTION
## Description
Append ca_bundle/1.0 and ca_pinning=enabled/ca_pinning=disabled to the User-Agent string based on the current pinning state. The User-Agent header is now set globally on the axios instance rather than per-request on the token endpoint

## Motivation and Context
Provides server-side visibility into which CA bundle version clients are running and whether CA pinning is active, enabling monitoring of CA pinning rollout and diagnosing certificate-related connectivity issues

## How Has This Been Tested?
- Added unit tests verifying the User-Agent string includes ca_bundle/1.0 and the correct ca_pinning=enabled or ca_pinning=disabled value based on client configuration.
- Existing test suite passes

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
